### PR TITLE
fix: tree node text not displaying in Safari

### DIFF
--- a/src/core/node/NodeComponents/ForeignNodeWrapper.tsx
+++ b/src/core/node/NodeComponents/ForeignNodeWrapper.tsx
@@ -14,16 +14,26 @@ export type ForeignNodeWrapper = {
 export function ForeignNodeWrapper(props: ForeignNodeWrapper) {
   return (
     <foreignObject
-      style={{ width: props.width, height: props.height }}
+      width={props.width}
+      height={props.height}
+      style={{ overflow: "hidden" }}
       {...(props.nodeId && { "data-node-id": props.nodeId })}
       className={classNames(
         firaMono.className,
         !props.isObject ? "text-center" : "",
-        "pointer-events-none overflow-hidden font-medium",
+        "pointer-events-none font-medium",
         props.isHighlighted ? "bg-[#ffd63427]" : "",
       )}
     >
-      {props.children}
+      <div
+        {...({ xmlns: "http://www.w3.org/1999/xhtml" } as Record<
+          string,
+          string
+        >)}
+        style={{ width: props.width, height: props.height }}
+      >
+        {props.children}
+      </div>
     </foreignObject>
   );
 }


### PR DESCRIPTION
## Summary
What changed and why?

- Fix tree node text not displaying in Safari. The `<foreignObject>` SVG element requires `width` and `height` as SVG attributes, not CSS inline styles. Safari renders the element with zero dimensions when only styles are used, making all HTML content inside invisible.
- Moved `width`/`height` from `style` to SVG attributes on `<foreignObject>`
- Moved `overflow: hidden` from Tailwind CSS class to inline `style` for cross-browser reliability on SVG elements
- Wrapped children in a `<div>` with explicit pixel dimensions and `xmlns="http://www.w3.org/1999/xhtml"` so Safari establishes a proper CSS containing block

## Type
- [ ] feature
- [x] fix
- [ ] hotfix
- [ ] chore
- [ ] docs
- [ ] test
- [ ] spike

## Testing
How was this verified?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- Notes: Verified in Safari that nodes render visible text. No apparent regressions in Chromium browsers.