### PR TITLE
feat: improve large JSON workflow with worker rendering, import/schema/stats, and copyable JSONPath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,10 @@
         "autoprefixer": "10.4.14",
         "eslint": "8.43.0",
         "eslint-config-next": "13.4.7",
-        "html-to-image": "^1.11.11",
+        "html-to-image": "1.11.11",
         "jsonc-parser": "^3.2.0",
         "lodash.debounce": "^4.0.8",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "next": "13.4.7",
+        "next": "14.2.35",
         "postcss": "8.4.24",
         "prettier": "^2.8.8",
         "prettier-plugin-tailwindcss": "^0.3.0",
@@ -319,9 +317,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.7.tgz",
-      "integrity": "sha512-ZlbiFulnwiFsW9UV1ku1OvX/oyIPLtMk9p/nnvDSwI0s7vSoZdRtxXNsaO+ZXrLv/pMbXVGq4lL8TbY9iuGmVw=="
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.4.7",
@@ -332,12 +331,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.7.tgz",
-      "integrity": "sha512-VZTxPv1b59KGiv/pZHTO5Gbsdeoxcj2rU2cqJu03btMhHpn3vwzEK0gUSVC/XW96aeGO67X+cMahhwHzef24/w==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -347,12 +347,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.7.tgz",
-      "integrity": "sha512-gO2bw+2Ymmga+QYujjvDz9955xvYGrWofmxTq7m70b9pDPvl7aDFABJOZ2a8SRCuSNB5mXU8eTOmVVwyp/nAew==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -362,12 +363,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.7.tgz",
-      "integrity": "sha512-6cqp3vf1eHxjIDhEOc7Mh/s8z1cwc/l5B6ZNkOofmZVyu1zsbEM5Hmx64s12Rd9AYgGoiCz4OJ4M/oRnkE16/Q==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -377,12 +382,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.7.tgz",
-      "integrity": "sha512-T1kD2FWOEy5WPidOn1si0rYmWORNch4a/NR52Ghyp4q7KyxOCuiOfZzyhVC5tsLIBDH3+cNdB5DkD9afpNDaOw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -392,12 +401,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.7.tgz",
-      "integrity": "sha512-zaEC+iEiAHNdhl6fuwl0H0shnTzQoAoJiDYBUze8QTntE/GNPfTYpYboxF5LRYIjBwETUatvE0T64W6SKDipvg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -407,12 +420,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.7.tgz",
-      "integrity": "sha512-X6r12F8d8SKAtYJqLZBBMIwEqcTRvUdVm+xIq+l6pJqlgT2tNsLLf2i5Cl88xSsIytBICGsCNNHd+siD2fbWBA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -422,12 +439,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.7.tgz",
-      "integrity": "sha512-NPnmnV+vEIxnu6SUvjnuaWRglZzw4ox5n/MQTxeUhb5iwVWFedolPFebMNwgrWu4AELwvTdGtWjqof53AiWHcw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -437,12 +455,13 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.7.tgz",
-      "integrity": "sha512-6Hxijm6/a8XqLQpOOf/XuwWRhcuc/g4rBB2oxjgCMuV9Xlr2bLs5+lXyh8w9YbAUMYR3iC9mgOlXbHa79elmXw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -452,12 +471,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.7.tgz",
-      "integrity": "sha512-sW9Yt36Db1nXJL+mTr2Wo0y+VkPWeYhygvcHj1FF0srVtV+VoDjxleKtny21QHaG05zdeZnw2fCtf2+dEqgwqA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -522,11 +542,19 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
       "integrity": "sha512-V+MvGwaHH03hYhY+k6Ef/xKd6RYlc4q8WBx+2ANmipHJcKuktNcI/NgEsJgdSUF6Lw32njT6OnrRsKYCdgHjYw=="
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
       "dependencies": {
+        "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
     },
@@ -1142,9 +1170,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001514",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz",
-      "integrity": "sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==",
+      "version": "1.0.30001778",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
+      "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1158,7 +1186,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2385,11 +2414,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-    },
     "node_modules/globals": {
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -3251,11 +3275,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -3265,11 +3284,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/log-update": {
       "version": "4.0.0",
@@ -3483,39 +3497,39 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/next": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.7.tgz",
-      "integrity": "sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "13.4.7",
-        "@swc/helpers": "0.5.1",
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
-        "caniuse-lite": "^1.0.30001406",
-        "postcss": "8.4.14",
-        "styled-jsx": "5.1.1",
-        "watchpack": "2.4.0",
-        "zod": "3.21.4"
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.8.0"
+        "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.7",
-        "@next/swc-darwin-x64": "13.4.7",
-        "@next/swc-linux-arm64-gnu": "13.4.7",
-        "@next/swc-linux-arm64-musl": "13.4.7",
-        "@next/swc-linux-x64-gnu": "13.4.7",
-        "@next/swc-linux-x64-musl": "13.4.7",
-        "@next/swc-win32-arm64-msvc": "13.4.7",
-        "@next/swc-win32-ia32-msvc": "13.4.7",
-        "@next/swc-win32-x64-msvc": "13.4.7"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "fibers": ">= 3.1.0",
+        "@playwright/test": "^1.41.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
@@ -3524,7 +3538,7 @@
         "@opentelemetry/api": {
           "optional": true
         },
-        "fibers": {
+        "@playwright/test": {
           "optional": true
         },
         "sass": {
@@ -3533,9 +3547,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3544,10 +3558,15 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -5315,18 +5334,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5448,14 +5455,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/src/components/EditorInfobar.tsx
+++ b/src/components/EditorInfobar.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function EditorInfobar() {
   const error = useApp((state) => state.error);
+  const stats = useApp((state) => state.stats);
   const schemaMode = useApp((state) => state.schemaMode);
   const autoManualMode = useApp((state) => state.autoManualMode);
   const pendingTransform = useApp((state) => state.pendingTransform);
@@ -57,6 +58,11 @@ export default function EditorInfobar() {
         {schemaMode && (
           <span className="rounded bg-yellow-400 px-2 py-[1px] text-[10px] font-semibold text-zinc-900">
             Schema mode
+          </span>
+        )}
+        {stats && (
+          <span className="hidden text-[10px] font-semibold text-zinc-600 dark:text-gray-300 md:inline">
+            Nodes {stats.totalNodes} | Depth {stats.maxDepth}
           </span>
         )}
         <div className="flex w-max space-x-1.5">

--- a/src/components/EditorInfobar.tsx
+++ b/src/components/EditorInfobar.tsx
@@ -21,6 +21,7 @@ export default function EditorInfobar() {
         <a
           href="https://github.com/BUMBAIYA/jsontree"
           target="_blank"
+          rel="noopener noreferrer"
           className="flex items-center space-x-1.5 hover:underline dark:text-white"
         >
           <span className="flex h-3.5 w-3.5">

--- a/src/components/EditorInfobar.tsx
+++ b/src/components/EditorInfobar.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function EditorInfobar() {
   const error = useApp((state) => state.error);
+  const schemaMode = useApp((state) => state.schemaMode);
   const autoManualMode = useApp((state) => state.autoManualMode);
   const pendingTransform = useApp((state) => state.pendingTransform);
   const applyPendingTransform = useApp((state) => state.applyPendingTransform);
@@ -53,6 +54,11 @@ export default function EditorInfobar() {
           <JsonIcon />
           JSON
         </span>
+        {schemaMode && (
+          <span className="rounded bg-yellow-400 px-2 py-[1px] text-[10px] font-semibold text-zinc-900">
+            Schema mode
+          </span>
+        )}
         <div className="flex w-max space-x-1.5">
           {error ? (
             <>

--- a/src/components/EditorInfobar.tsx
+++ b/src/components/EditorInfobar.tsx
@@ -9,6 +9,10 @@ import {
 
 export default function EditorInfobar() {
   const error = useApp((state) => state.error);
+  const autoManualMode = useApp((state) => state.autoManualMode);
+  const pendingTransform = useApp((state) => state.pendingTransform);
+  const applyPendingTransform = useApp((state) => state.applyPendingTransform);
+
   return (
     <div className="flex h-7 w-full items-center justify-between gap-4 border-t border-zinc-300 bg-white px-2 text-xs dark:border-zinc-700 dark:bg-vsdark-500 md:px-4">
       <div className="flex items-center space-x-4">
@@ -30,7 +34,21 @@ export default function EditorInfobar() {
           Github
         </a>
       </div>
-      <div className="flex items-center space-x-4">
+      <div className="flex items-center space-x-2 md:space-x-4">
+        {autoManualMode && (
+          <span className="hidden text-[10px] font-semibold text-yellow-700 dark:text-yellow-400 md:inline">
+            Large JSON mode
+          </span>
+        )}
+        {pendingTransform && (
+          <button
+            type="button"
+            onClick={() => void applyPendingTransform()}
+            className="rounded bg-yellow-400 px-2 py-[1px] font-semibold text-zinc-900 hover:bg-yellow-300"
+          >
+            Update graph
+          </button>
+        )}
         <span className="hidden h-4 items-center gap-1 dark:text-white sm:flex">
           <JsonIcon />
           JSON

--- a/src/components/EditorInfobar.tsx
+++ b/src/components/EditorInfobar.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from "react";
 import { useApp } from "@/store/useApp";
+import { useTree } from "@/store/useTree";
 import {
   CheckIcon,
   ErrorIcon,
@@ -14,6 +16,45 @@ export default function EditorInfobar() {
   const autoManualMode = useApp((state) => state.autoManualMode);
   const pendingTransform = useApp((state) => state.pendingTransform);
   const applyPendingTransform = useApp((state) => state.applyPendingTransform);
+  const selectedNodeId = useTree((state) => state.selectedNode.id);
+  const selectedPath = useTree((state) => state.path);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
+    "idle",
+  );
+
+  const handleCopyPath = async () => {
+    if (!selectedPath) return;
+
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(selectedPath);
+      } else if (typeof document !== "undefined") {
+        const textarea = document.createElement("textarea");
+        textarea.value = selectedPath;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+  };
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    const timer = setTimeout(() => setCopyState("idle"), 1400);
+    return () => clearTimeout(timer);
+  }, [copyState]);
+
+  useEffect(() => {
+    setCopyState("idle");
+  }, [selectedNodeId, selectedPath]);
 
   return (
     <div className="flex h-7 w-full items-center justify-between gap-4 border-t border-zinc-300 bg-white px-2 text-xs dark:border-zinc-700 dark:bg-vsdark-500 md:px-4">
@@ -37,6 +78,27 @@ export default function EditorInfobar() {
         </a>
       </div>
       <div className="flex items-center space-x-2 md:space-x-4">
+        {selectedNodeId && selectedPath && (
+          <div className="hidden max-w-[36vw] items-center gap-2 md:flex">
+            <span
+              title={selectedPath}
+              className="truncate text-[10px] font-medium text-zinc-600 dark:text-gray-300"
+            >
+              Path {selectedPath}
+            </span>
+            <button
+              type="button"
+              onClick={() => void handleCopyPath()}
+              className="rounded border border-gray-300 px-2 py-[1px] text-[10px] font-semibold text-zinc-700 hover:bg-gray-100 dark:border-gray-500 dark:text-gray-200 dark:hover:border-yellow-400 dark:hover:text-yellow-400"
+            >
+              {copyState === "copied"
+                ? "Copied"
+                : copyState === "error"
+                ? "Failed"
+                : "Copy path"}
+            </button>
+          </div>
+        )}
         {autoManualMode && (
           <span className="hidden text-[10px] font-semibold text-yellow-700 dark:text-yellow-400 md:inline">
             Large JSON mode

--- a/src/components/Toolbar/Shortcuts.tsx
+++ b/src/components/Toolbar/Shortcuts.tsx
@@ -16,7 +16,12 @@ import {
 import { useStored } from "@/store/useStored";
 import { DownloadImageModal } from "@/components/modals/DownloadImageModal";
 
-export default function Shortcuts() {
+type ShortcutsProps = {
+  onOpenImportModal: () => void;
+};
+
+export default function Shortcuts(props: ShortcutsProps) {
+  const { onOpenImportModal } = props;
   const fullscreen = useTree((state) => state.fullscreen);
   const toggleFullscreen = useTree((state) => state.toggleFullscreen);
   const theme = useStored((state) => state.lightmode);
@@ -50,6 +55,7 @@ export default function Shortcuts() {
   useHotkeys([
     ["mod,shift,E", toggleEditor],
     ["mod,shift,D", toggleDirection],
+    ["mod,shift,I", onOpenImportModal],
   ]);
 
   return (
@@ -99,6 +105,32 @@ export default function Shortcuts() {
                     }`}
                   >
                     {modKey} SHIFT E
+                  </kbd>
+                </button>
+              )}
+            </Menu.Item>
+            <Menu.Item>
+              {({ active }) => (
+                <button
+                  className={`${
+                    active
+                      ? "bg-gray-900 text-white dark:text-yellow-400"
+                      : "text-gray-900 dark:text-white"
+                  } group flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm md:justify-between`}
+                  onClick={onOpenImportModal}
+                >
+                  <div className="h-4 w-4">
+                    <JsonIcon />
+                  </div>
+                  Import package.json
+                  <kbd
+                    className={`ml-2 hidden rounded-md border border-gray-200 p-1 text-xs md:inline ${
+                      active
+                        ? "border-gray-100 bg-yellow-300 text-gray-900"
+                        : "bg-gray-200 dark:text-gray-900"
+                    }`}
+                  >
+                    {modKey} SHIFT I
                   </kbd>
                 </button>
               )}

--- a/src/components/Toolbar/Shortcuts.tsx
+++ b/src/components/Toolbar/Shortcuts.tsx
@@ -18,11 +18,12 @@ import { DownloadImageModal } from "@/components/modals/DownloadImageModal";
 
 type ShortcutsProps = {
   onOpenImportModal: () => void;
+  onOpenStatsModal: () => void;
   onToggleSchemaMode: () => void;
 };
 
 export default function Shortcuts(props: ShortcutsProps) {
-  const { onOpenImportModal, onToggleSchemaMode } = props;
+  const { onOpenImportModal, onOpenStatsModal, onToggleSchemaMode } = props;
   const fullscreen = useTree((state) => state.fullscreen);
   const toggleFullscreen = useTree((state) => state.toggleFullscreen);
   const theme = useStored((state) => state.lightmode);
@@ -57,6 +58,7 @@ export default function Shortcuts(props: ShortcutsProps) {
     ["mod,shift,E", toggleEditor],
     ["mod,shift,D", toggleDirection],
     ["mod,shift,I", onOpenImportModal],
+    ["mod,shift,J", onOpenStatsModal],
     ["mod,shift,S", onToggleSchemaMode],
   ]);
 
@@ -107,6 +109,32 @@ export default function Shortcuts(props: ShortcutsProps) {
                     }`}
                   >
                     {modKey} SHIFT E
+                  </kbd>
+                </button>
+              )}
+            </Menu.Item>
+            <Menu.Item>
+              {({ active }) => (
+                <button
+                  className={`${
+                    active
+                      ? "bg-gray-900 text-white dark:text-yellow-400"
+                      : "text-gray-900 dark:text-white"
+                  } group flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm md:justify-between`}
+                  onClick={onOpenStatsModal}
+                >
+                  <div className="h-4 w-4">
+                    <JsonIcon />
+                  </div>
+                  JSON Stats
+                  <kbd
+                    className={`ml-2 hidden rounded-md border border-gray-200 p-1 text-xs md:inline ${
+                      active
+                        ? "border-gray-100 bg-yellow-300 text-gray-900"
+                        : "bg-gray-200 dark:text-gray-900"
+                    }`}
+                  >
+                    {modKey} SHIFT J
                   </kbd>
                 </button>
               )}

--- a/src/components/Toolbar/Shortcuts.tsx
+++ b/src/components/Toolbar/Shortcuts.tsx
@@ -18,10 +18,11 @@ import { DownloadImageModal } from "@/components/modals/DownloadImageModal";
 
 type ShortcutsProps = {
   onOpenImportModal: () => void;
+  onToggleSchemaMode: () => void;
 };
 
 export default function Shortcuts(props: ShortcutsProps) {
-  const { onOpenImportModal } = props;
+  const { onOpenImportModal, onToggleSchemaMode } = props;
   const fullscreen = useTree((state) => state.fullscreen);
   const toggleFullscreen = useTree((state) => state.toggleFullscreen);
   const theme = useStored((state) => state.lightmode);
@@ -56,6 +57,7 @@ export default function Shortcuts(props: ShortcutsProps) {
     ["mod,shift,E", toggleEditor],
     ["mod,shift,D", toggleDirection],
     ["mod,shift,I", onOpenImportModal],
+    ["mod,shift,S", onToggleSchemaMode],
   ]);
 
   return (
@@ -105,6 +107,32 @@ export default function Shortcuts(props: ShortcutsProps) {
                     }`}
                   >
                     {modKey} SHIFT E
+                  </kbd>
+                </button>
+              )}
+            </Menu.Item>
+            <Menu.Item>
+              {({ active }) => (
+                <button
+                  className={`${
+                    active
+                      ? "bg-gray-900 text-white dark:text-yellow-400"
+                      : "text-gray-900 dark:text-white"
+                  } group flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm md:justify-between`}
+                  onClick={onToggleSchemaMode}
+                >
+                  <div className="h-4 w-4">
+                    <JsonIcon />
+                  </div>
+                  Toggle Schema Mode
+                  <kbd
+                    className={`ml-2 hidden rounded-md border border-gray-200 p-1 text-xs md:inline ${
+                      active
+                        ? "border-gray-100 bg-yellow-300 text-gray-900"
+                        : "bg-gray-200 dark:text-gray-900"
+                    }`}
+                  >
+                    {modKey} SHIFT S
                   </kbd>
                 </button>
               )}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
 import { JsonIcon } from "@/components/icons";
 import { ImportPackageJsonModal } from "@/components/modals/ImportPackageJsonModal";
+import { useApp } from "@/store/useApp";
 import Tools from "@/components/Toolbar/Tools";
 import Shortcuts from "./Shortcuts";
 import { Searchbar } from "../Searchbar";
 
 export function Toolbar() {
   const [isImportModalOpen, setIsImportModal] = useState(false);
+  const schemaMode = useApp((state) => state.schemaMode);
+  const toggleSchemaMode = useApp((state) => state.toggleSchemaMode);
   const openImportModal = () => setIsImportModal(true);
 
   return (
@@ -23,8 +26,25 @@ export function Toolbar() {
         </span>
         <span className="hidden sm:inline">Import</span>
       </button>
+      <button
+        type="button"
+        aria-label={
+          schemaMode ? "Switch to data mode" : "Switch to schema mode"
+        }
+        onClick={() => void toggleSchemaMode()}
+        className={`inline-flex h-8 items-center justify-center rounded-md border px-2 py-1 text-sm ${
+          schemaMode
+            ? "border-yellow-400 bg-yellow-400 text-zinc-900"
+            : "border-gray-300 text-gray-700 hover:bg-gray-200 dark:border-gray-500 dark:bg-vsdark-500 dark:text-gray-300 dark:hover:border-yellow-400 dark:hover:text-yellow-400"
+        }`}
+      >
+        {schemaMode ? "Data" : "Schema"}
+      </button>
       <Tools />
-      <Shortcuts onOpenImportModal={openImportModal} />
+      <Shortcuts
+        onOpenImportModal={openImportModal}
+        onToggleSchemaMode={() => void toggleSchemaMode()}
+      />
       <ImportPackageJsonModal
         isOpen={isImportModalOpen}
         setOpen={setIsImportModal}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { JsonIcon } from "@/components/icons";
 import { ImportPackageJsonModal } from "@/components/modals/ImportPackageJsonModal";
+import { JsonStatsModal } from "@/components/modals/JsonStatsModal";
 import { useApp } from "@/store/useApp";
 import Tools from "@/components/Toolbar/Tools";
 import Shortcuts from "./Shortcuts";
@@ -8,9 +9,11 @@ import { Searchbar } from "../Searchbar";
 
 export function Toolbar() {
   const [isImportModalOpen, setIsImportModal] = useState(false);
+  const [isStatsModalOpen, setIsStatsModal] = useState(false);
   const schemaMode = useApp((state) => state.schemaMode);
   const toggleSchemaMode = useApp((state) => state.toggleSchemaMode);
   const openImportModal = () => setIsImportModal(true);
+  const openStatsModal = () => setIsStatsModal(true);
 
   return (
     <div className="flex items-center gap-2">
@@ -40,15 +43,25 @@ export function Toolbar() {
       >
         {schemaMode ? "Data" : "Schema"}
       </button>
+      <button
+        type="button"
+        aria-label="Open JSON stats"
+        onClick={openStatsModal}
+        className="inline-flex h-8 items-center justify-center rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-200 dark:border-gray-500 dark:bg-vsdark-500 dark:text-gray-300 dark:hover:border-yellow-400 dark:hover:text-yellow-400"
+      >
+        Stats
+      </button>
       <Tools />
       <Shortcuts
         onOpenImportModal={openImportModal}
+        onOpenStatsModal={openStatsModal}
         onToggleSchemaMode={() => void toggleSchemaMode()}
       />
       <ImportPackageJsonModal
         isOpen={isImportModalOpen}
         setOpen={setIsImportModal}
       />
+      <JsonStatsModal isOpen={isStatsModalOpen} setOpen={setIsStatsModal} />
     </div>
   );
 }

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,13 +1,34 @@
+import { useState } from "react";
+import { JsonIcon } from "@/components/icons";
+import { ImportPackageJsonModal } from "@/components/modals/ImportPackageJsonModal";
 import Tools from "@/components/Toolbar/Tools";
 import Shortcuts from "./Shortcuts";
 import { Searchbar } from "../Searchbar";
 
 export function Toolbar() {
+  const [isImportModalOpen, setIsImportModal] = useState(false);
+  const openImportModal = () => setIsImportModal(true);
+
   return (
     <div className="flex items-center gap-2">
       <Searchbar />
+      <button
+        type="button"
+        aria-label="Import package.json"
+        onClick={openImportModal}
+        className="inline-flex h-8 w-8 items-center justify-center gap-1 rounded-md border border-gray-300 p-0 text-sm text-gray-700 hover:bg-gray-200 dark:border-gray-500 dark:bg-vsdark-500 dark:text-gray-300 dark:hover:border-yellow-400 dark:hover:text-yellow-400 sm:w-auto sm:px-2 sm:py-1"
+      >
+        <span className="h-4 w-4">
+          <JsonIcon />
+        </span>
+        <span className="hidden sm:inline">Import</span>
+      </button>
       <Tools />
-      <Shortcuts />
+      <Shortcuts onOpenImportModal={openImportModal} />
+      <ImportPackageJsonModal
+        isOpen={isImportModalOpen}
+        setOpen={setIsImportModal}
+      />
     </div>
   );
 }

--- a/src/components/TreeEditor/index.tsx
+++ b/src/components/TreeEditor/index.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Edge, EdgeProps, ElkRoot, NodeProps } from "reaflow";
 import {
   ReactZoomPanPinchRef,
@@ -7,7 +7,6 @@ import {
   TransformWrapper,
 } from "react-zoom-pan-pinch";
 import { useTree } from "@/store/useTree";
-import useToggleHide from "@/hooks/useToggleHide";
 import { CustomNode } from "@/core/node";
 import { useElementSize } from "@/hooks/useElementSize";
 import { useStored } from "@/store/useStored";
@@ -16,20 +15,38 @@ const Canvas = dynamic(() => import("reaflow").then((r) => r.Canvas));
 
 export default function TreeEditor() {
   const loading = useTree((state) => state.loading);
-  const { validateHiddenNodes } = useToggleHide();
-  const setLoading = useTree((state) => state.setLoading);
+  const loadedNodes = useTree((state) => state.loadedNodes);
+  const totalNodes = useTree((state) => state.totalNodes);
   const setZoomPanPinch = useTree((state) => state.setZoomPanPinch);
-  const centerView = useTree((state) => state.centerView);
   const lightmode = useStored((state) => state.lightmode);
 
   const direction = useTree((state) => state.direction);
   const nodes = useTree((state) => state.nodes);
   const edges = useTree((state) => state.edges);
+  const collapsedNodes = useTree((state) => state.collapsedNodes);
+  const collapsedEdges = useTree((state) => state.collapsedEdges);
 
   const [paneWidth, setPaneWidth] = useState(2000);
   const [paneHeight, setPaneHeight] = useState(2000);
 
   const [editorContainerRef, editorSize] = useElementSize();
+
+  const renderNodes = useMemo(() => {
+    const hiddenNodeIds = new Set(collapsedNodes);
+    return nodes.filter((node) => !hiddenNodeIds.has(node.id));
+  }, [collapsedNodes, nodes]);
+
+  const renderEdges = useMemo(() => {
+    const hiddenNodeIds = new Set(collapsedNodes);
+    const hiddenEdgeIds = new Set(collapsedEdges);
+
+    return edges.filter((edge) => {
+      if (hiddenEdgeIds.has(edge.id)) return false;
+      if (edge.from && hiddenNodeIds.has(edge.from)) return false;
+      if (edge.to && hiddenNodeIds.has(edge.to)) return false;
+      return true;
+    });
+  }, [collapsedEdges, collapsedNodes, edges]);
 
   const onInit = useCallback(
     (ref: ReactZoomPanPinchRef) => {
@@ -38,28 +55,12 @@ export default function TreeEditor() {
     [setZoomPanPinch],
   );
 
-  const onLayoutChange = useCallback(
-    (layout: ElkRoot) => {
-      if (layout.width && layout.height) {
-        const areaSize = layout.width * layout.height;
-        const changeRatio = Math.abs(
-          (areaSize * 100) / (paneWidth * paneHeight) - 100,
-        );
-
-        setPaneWidth(layout.width + 50);
-        setPaneHeight((layout.height as number) + 50);
-
-        setTimeout(() => {
-          setLoading(false);
-          validateHiddenNodes();
-          window.requestAnimationFrame(() => {
-            if (changeRatio > 70 || false) centerView();
-          });
-        });
-      }
-    },
-    [centerView, paneHeight, paneWidth, setLoading, validateHiddenNodes],
-  );
+  const onLayoutChange = useCallback((layout: ElkRoot) => {
+    if (layout.width && layout.height) {
+      setPaneWidth(layout.width + 50);
+      setPaneHeight((layout.height as number) + 50);
+    }
+  }, []);
 
   const memoizedNode = useCallback(
     (props: JSX.IntrinsicAttributes & NodeProps<any>) => (
@@ -78,9 +79,14 @@ export default function TreeEditor() {
   return (
     <>
       {loading && (
-        <div className="pointer-events-none absolute inset-0 left-0 top-0 z-50 flex items-center justify-center bg-white dark:bg-vsdark-500 dark:text-white">
-          <div className="text-base">
-            <span>Building graph...</span>
+        <div className="bg-white/85 pointer-events-none absolute right-2 top-2 z-50 rounded-md px-3 py-1.5 text-xs font-medium text-zinc-700 shadow-sm dark:bg-vsdark-500/90 dark:text-gray-200">
+          <div className="flex items-center gap-2">
+            <span>Building graph</span>
+            {totalNodes > 0 && (
+              <span className="font-semibold text-yellow-700 dark:text-yellow-400">
+                {loadedNodes}/{totalNodes}
+              </span>
+            )}
           </div>
         </div>
       )}
@@ -116,13 +122,13 @@ export default function TreeEditor() {
               width: "100%",
               height: "100%",
               overflow: "hidden",
-              display: loading ? "none" : "block",
+              display: "block",
             }}
           >
             <Canvas
               className="jsontree-canvas"
-              nodes={nodes}
-              edges={edges}
+              nodes={renderNodes}
+              edges={renderEdges}
               maxHeight={paneHeight}
               maxWidth={paneWidth}
               height={paneHeight}

--- a/src/components/modals/ImportPackageJsonModal.tsx
+++ b/src/components/modals/ImportPackageJsonModal.tsx
@@ -1,0 +1,189 @@
+import { Dialog, Transition } from "@headlessui/react";
+import { Dispatch, Fragment, SetStateAction, useMemo, useState } from "react";
+import { CancelIcon } from "@/components/icons";
+import { useApp } from "@/store/useApp";
+
+type ImportResponse = {
+  source: "github" | "npm";
+  identifier: string;
+  pretty: string;
+};
+
+type ImportErrorResponse = {
+  error?: string;
+};
+
+export type ImportPackageJsonModalProps = {
+  isOpen: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+const examples = [
+  "https://github.com/vercel/next.js",
+  "https://github.com/facebook/react/tree/main/packages/react",
+  "react",
+  "https://www.npmjs.com/package/zustand",
+];
+
+export function ImportPackageJsonModal(props: ImportPackageJsonModalProps) {
+  const { isOpen, setOpen } = props;
+  const setContents = useApp((state) => state.setContents);
+
+  const [source, setSource] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const canImport = useMemo(
+    () => source.trim().length > 0 && !loading,
+    [loading, source],
+  );
+
+  const handleClose = () => {
+    setLoading(false);
+    setError("");
+    setOpen(false);
+  };
+
+  const handleImport = async () => {
+    const value = source.trim();
+    if (!value) {
+      setError("Provide a GitHub URL, npm URL, or package name.");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const response = await fetch("/api/import-package-json", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ source: value }),
+      });
+
+      const data = (await response.json()) as
+        | ImportResponse
+        | ImportErrorResponse;
+
+      if (!response.ok) {
+        const errorResponse = data as ImportErrorResponse;
+        throw new Error(errorResponse.error || "Failed to import package.json");
+      }
+
+      const payload = data as ImportResponse;
+      await setContents({
+        contents: payload.pretty,
+        hasChanges: true,
+        skipUpdate: false,
+      });
+
+      handleClose();
+    } catch (requestError: any) {
+      setError(requestError?.message || "Failed to import package.json");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={handleClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-30 dark:bg-black dark:bg-opacity-60" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-xl rounded-lg bg-white p-4 ring-1 ring-gray-500/20 dark:bg-zinc-800 dark:text-gray-300 dark:ring-gray-100/20">
+                <div className="flex items-center justify-between">
+                  <span className="font-semibold dark:text-gray-200">
+                    Import package.json
+                  </span>
+                  <button
+                    type="button"
+                    className="h-5 w-5 rounded-full text-gray-500 hover:text-gray-600 dark:text-gray-200 dark:hover:text-yellow-400"
+                    onClick={handleClose}
+                  >
+                    <CancelIcon />
+                  </button>
+                </div>
+
+                <div className="mt-4">
+                  <label
+                    htmlFor="import-source"
+                    className="block text-sm font-medium dark:text-gray-200"
+                  >
+                    GitHub URL, npm URL, or npm package
+                  </label>
+                  <input
+                    id="import-source"
+                    type="text"
+                    value={source}
+                    onChange={(event) => setSource(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" && canImport) {
+                        event.preventDefault();
+                        void handleImport();
+                      }
+                    }}
+                    placeholder="https://github.com/vercel/next.js or react"
+                    className="mt-2 block w-full rounded-md border-0 px-3.5 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-1 focus:ring-inset focus:ring-yellow-400 dark:bg-vsdark-500 dark:text-gray-200 dark:ring-0 dark:focus:ring-1 sm:text-sm sm:leading-6"
+                    autoFocus
+                  />
+                </div>
+
+                <div className="mt-3 rounded-md bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-zinc-700 dark:text-gray-200">
+                  <span className="font-semibold">Examples:</span>{" "}
+                  {examples.join(" | ")}
+                </div>
+
+                {error && (
+                  <div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-300">
+                    {error}
+                  </div>
+                )}
+
+                <div className="mt-5 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-500 dark:text-gray-200 dark:hover:bg-zinc-700"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleImport()}
+                    disabled={!canImport}
+                    className="rounded-md bg-yellow-400 px-4 py-2 text-sm font-semibold text-zinc-900 hover:bg-yellow-300 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {loading ? "Importing..." : "Import package.json"}
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/src/components/modals/JsonStatsModal.tsx
+++ b/src/components/modals/JsonStatsModal.tsx
@@ -1,0 +1,150 @@
+import { Dialog, Transition } from "@headlessui/react";
+import { Dispatch, Fragment, SetStateAction } from "react";
+import { CancelIcon } from "@/components/icons";
+import { useApp } from "@/store/useApp";
+
+export type JsonStatsModalProps = {
+  isOpen: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+const TYPE_LABELS: Array<{
+  id: "object" | "array" | "string" | "number" | "boolean" | "null";
+  label: string;
+}> = [
+  { id: "object", label: "Objects" },
+  { id: "array", label: "Arrays" },
+  { id: "string", label: "Strings" },
+  { id: "number", label: "Numbers" },
+  { id: "boolean", label: "Booleans" },
+  { id: "null", label: "Nulls" },
+];
+
+export function JsonStatsModal(props: JsonStatsModalProps) {
+  const { isOpen, setOpen } = props;
+  const stats = useApp((state) => state.stats);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={handleClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-30 dark:bg-black dark:bg-opacity-60" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-xl rounded-lg bg-white p-4 ring-1 ring-gray-500/20 dark:bg-zinc-800 dark:text-gray-300 dark:ring-gray-100/20">
+                <div className="flex items-center justify-between">
+                  <span className="font-semibold dark:text-gray-200">
+                    JSON Stats
+                  </span>
+                  <button
+                    type="button"
+                    className="h-5 w-5 rounded-full text-gray-500 hover:text-gray-600 dark:text-gray-200 dark:hover:text-yellow-400"
+                    onClick={handleClose}
+                  >
+                    <CancelIcon />
+                  </button>
+                </div>
+
+                {!stats ? (
+                  <div className="mt-4 rounded-md border border-gray-200 bg-gray-50 px-3 py-3 text-sm text-gray-700 dark:border-gray-600 dark:bg-zinc-700 dark:text-gray-200">
+                    No stats yet. Validate/update JSON to generate stats.
+                  </div>
+                ) : (
+                  <>
+                    <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                      <div className="rounded-md border border-gray-200 px-3 py-2 dark:border-gray-600">
+                        <div className="text-[11px] uppercase text-gray-500 dark:text-gray-400">
+                          Total nodes
+                        </div>
+                        <div className="text-lg font-semibold">
+                          {stats.totalNodes}
+                        </div>
+                      </div>
+                      <div className="rounded-md border border-gray-200 px-3 py-2 dark:border-gray-600">
+                        <div className="text-[11px] uppercase text-gray-500 dark:text-gray-400">
+                          Max depth
+                        </div>
+                        <div className="text-lg font-semibold">
+                          {stats.maxDepth}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="mt-4">
+                      <div className="text-sm font-semibold dark:text-gray-200">
+                        Types
+                      </div>
+                      <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                        {TYPE_LABELS.map((type) => (
+                          <div
+                            key={type.id}
+                            className="rounded-md border border-gray-200 px-3 py-2 dark:border-gray-600"
+                          >
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                              {type.label}
+                            </div>
+                            <div className="text-base font-semibold">
+                              {stats.typeCounts[type.id]}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="mt-4">
+                      <div className="text-sm font-semibold dark:text-gray-200">
+                        Most common keys
+                      </div>
+                      <div className="mt-2 max-h-56 overflow-auto rounded-md border border-gray-200 dark:border-gray-600">
+                        {stats.topKeys.length === 0 ? (
+                          <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+                            No object keys found.
+                          </div>
+                        ) : (
+                          stats.topKeys.map((entry) => (
+                            <div
+                              key={entry.key}
+                              className="flex items-center justify-between border-b border-gray-100 px-3 py-2 text-sm last:border-b-0 dark:border-gray-700"
+                            >
+                              <span className="font-mono">{entry.key}</span>
+                              <span className="font-semibold">
+                                {entry.count}
+                              </span>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+                  </>
+                )}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/src/core/graph/getCollapsedGraphState.ts
+++ b/src/core/graph/getCollapsedGraphState.ts
@@ -1,0 +1,55 @@
+import { EdgeData, NodeData } from "@/core/type";
+
+type CollapsedGraphState = {
+  collapsedParents: string[];
+  collapsedNodes: string[];
+  collapsedEdges: string[];
+  graphCollapsed: boolean;
+};
+
+export function getCollapsedGraphState(
+  nodes: NodeData[],
+  edges: EdgeData[],
+): CollapsedGraphState {
+  const toIds = new Set(
+    edges.map((edge) => edge.to).filter((id): id is string => Boolean(id)),
+  );
+  const parentNodesIds = Array.from(
+    new Set(
+      edges
+        .map((edge) => edge.from)
+        .filter((id): id is string => {
+          if (!id) return false;
+          return !toIds.has(id);
+        }),
+    ),
+  );
+
+  const parentNodesSet = new Set(parentNodesIds);
+  const secondDegreeNodesIds = new Set(
+    edges
+      .filter((edge) => edge.from && parentNodesSet.has(edge.from))
+      .map((edge) => edge.to)
+      .filter((id): id is string => Boolean(id)),
+  );
+
+  const collapsedParents = nodes
+    .filter((node) => !parentNodesSet.has(node.id) && node.data?.isParent)
+    .map((node) => node.id);
+  const collapsedNodes = nodes
+    .filter(
+      (node) =>
+        !parentNodesSet.has(node.id) && !secondDegreeNodesIds.has(node.id),
+    )
+    .map((node) => node.id);
+  const collapsedEdges = edges
+    .filter((edge) => edge.from && !parentNodesSet.has(edge.from))
+    .map((edge) => edge.id);
+
+  return {
+    collapsedParents,
+    collapsedNodes,
+    collapsedEdges,
+    graphCollapsed: collapsedNodes.length > 0 || collapsedEdges.length > 0,
+  };
+}

--- a/src/core/graph/workerTypes.ts
+++ b/src/core/graph/workerTypes.ts
@@ -1,0 +1,43 @@
+import { EdgeData, NodeData } from "@/core/type";
+
+export type BuildGraphRequest = {
+  type: "BUILD_GRAPH";
+  jobId: number;
+  json: string;
+  chunkSize: number;
+  autoCollapseThreshold: number;
+};
+
+export type GraphWorkerStartMessage = {
+  type: "GRAPH_START";
+  jobId: number;
+  totalNodes: number;
+  totalEdges: number;
+  largeGraphMode: boolean;
+  collapsedParents: string[];
+  collapsedNodes: string[];
+  collapsedEdges: string[];
+  graphCollapsed: boolean;
+};
+
+export type GraphWorkerChunkMessage = {
+  type: "GRAPH_CHUNK";
+  jobId: number;
+  nodes: NodeData[];
+  edges: EdgeData[];
+  loadedNodes: number;
+  loadedEdges: number;
+  done: boolean;
+};
+
+export type GraphWorkerErrorMessage = {
+  type: "GRAPH_ERROR";
+  jobId: number;
+  message: string;
+};
+
+export type GraphWorkerRequest = BuildGraphRequest;
+export type GraphWorkerResponse =
+  | GraphWorkerStartMessage
+  | GraphWorkerChunkMessage
+  | GraphWorkerErrorMessage;

--- a/src/core/json/getJsonStats.ts
+++ b/src/core/json/getJsonStats.ts
@@ -1,0 +1,116 @@
+export type JsonNodeType =
+  | "object"
+  | "array"
+  | "string"
+  | "number"
+  | "boolean"
+  | "null";
+
+export type JsonStats = {
+  totalNodes: number;
+  maxDepth: number;
+  typeCounts: Record<JsonNodeType, number>;
+  topKeys: Array<{ key: string; count: number }>;
+};
+
+type StackItem = {
+  value: unknown;
+  depth: number;
+};
+
+const EMPTY_STATS: JsonStats = {
+  totalNodes: 0,
+  maxDepth: 0,
+  typeCounts: {
+    object: 0,
+    array: 0,
+    string: 0,
+    number: 0,
+    boolean: 0,
+    null: 0,
+  },
+  topKeys: [],
+};
+
+function sortTopKeys(keyMap: Map<string, number>) {
+  return Array.from(keyMap.entries())
+    .sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[0].localeCompare(b[0]);
+    })
+    .slice(0, 8)
+    .map(([key, count]) => ({ key, count }));
+}
+
+export function getJsonStats(json: unknown): JsonStats {
+  if (json === undefined) return EMPTY_STATS;
+
+  const typeCounts: Record<JsonNodeType, number> = {
+    object: 0,
+    array: 0,
+    string: 0,
+    number: 0,
+    boolean: 0,
+    null: 0,
+  };
+  const keyCountMap = new Map<string, number>();
+
+  let totalNodes = 0;
+  let maxDepth = 0;
+
+  const stack: StackItem[] = [{ value: json, depth: 1 }];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+
+    const { value, depth } = current;
+    totalNodes += 1;
+    if (depth > maxDepth) maxDepth = depth;
+
+    if (value === null) {
+      typeCounts.null += 1;
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      typeCounts.array += 1;
+      for (let i = value.length - 1; i >= 0; i -= 1) {
+        stack.push({ value: value[i], depth: depth + 1 });
+      }
+      continue;
+    }
+
+    if (typeof value === "object") {
+      typeCounts.object += 1;
+      const entries = Object.entries(value as Record<string, unknown>);
+      for (let i = entries.length - 1; i >= 0; i -= 1) {
+        const [key, childValue] = entries[i];
+        keyCountMap.set(key, (keyCountMap.get(key) || 0) + 1);
+        stack.push({ value: childValue, depth: depth + 1 });
+      }
+      continue;
+    }
+
+    if (typeof value === "string") {
+      typeCounts.string += 1;
+      continue;
+    }
+
+    if (typeof value === "number") {
+      typeCounts.number += 1;
+      continue;
+    }
+
+    if (typeof value === "boolean") {
+      typeCounts.boolean += 1;
+    }
+  }
+
+  return {
+    totalNodes,
+    maxDepth,
+    typeCounts,
+    topKeys: sortTopKeys(keyCountMap),
+  };
+}

--- a/src/core/json/getNodePath.ts
+++ b/src/core/json/getNodePath.ts
@@ -1,61 +1,98 @@
 import { EdgeData, NodeData } from "@/core/type";
 
+const IDENTIFIER_REGEX = /^[A-Za-z_$][\w$]*$/;
+
+const normalizeKey = (value: unknown) => {
+  if (typeof value !== "string") return null;
+  const key = value.trim();
+  if (!key || key === "{}" || key === "[]") return null;
+  return key;
+};
+
+const appendObjectKey = (path: string, key: string) => {
+  if (IDENTIFIER_REGEX.test(key)) {
+    return `${path}.${key}`;
+  }
+
+  const escapedKey = key.replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+  return `${path}['${escapedKey}']`;
+};
+
 export function getNodePath(
   nodes: NodeData[],
   edges: EdgeData[],
   nodeId: string,
 ) {
-  const { getParentsForNodeId } = require("reaflow");
+  if (!nodeId || nodes.length === 0) return "$";
 
-  let resolvedPath = "";
-  // TODO: Infere types of getParentsForNodeID not found on reaflow library so explicitly set to string
-  const parentIds = getParentsForNodeId(nodes, edges, nodeId).map(
-    (n: { id: string }) => n.id,
-  );
-  const path = parentIds.reverse().concat(nodeId);
-  const rootArrayElementIds = ["1"];
-  const edgesMap = new Map();
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  const parentByChild = new Map<string, string>();
+  const childrenByParent = new Map<string, string[]>();
 
   for (const edge of edges) {
-    if (!edgesMap.has(edge.from!)) {
-      edgesMap.set(edge.from!, []);
+    if (!edge.from || !edge.to) continue;
+    if (!parentByChild.has(edge.to)) {
+      parentByChild.set(edge.to, edge.from);
     }
-    edgesMap.get(edge.from!).push(edge.to);
+    const children = childrenByParent.get(edge.from) ?? [];
+    children.push(edge.to);
+    childrenByParent.set(edge.from, children);
   }
 
-  for (let i = 1; i < edges.length; i++) {
-    const curNodeId = edges[i].from!;
-    if (rootArrayElementIds.includes(curNodeId)) continue;
-    if (!edgesMap.has(curNodeId)) {
-      rootArrayElementIds.push(curNodeId);
+  const chain: string[] = [];
+  const seen = new Set<string>();
+  let currentId: string | undefined = nodeId;
+
+  while (currentId && !seen.has(currentId)) {
+    chain.push(currentId);
+    seen.add(currentId);
+    currentId = parentByChild.get(currentId);
+  }
+
+  if (chain.length === 0) return "$";
+  chain.reverse();
+
+  let resolvedPath = "$";
+  const rootNode = nodeMap.get(chain[0]);
+
+  if (rootNode && !rootNode.data?.isEmpty) {
+    const rootKey = normalizeKey(rootNode.text);
+    if (
+      (rootNode.data?.type === "object" || rootNode.data?.type === "array") &&
+      rootKey
+    ) {
+      resolvedPath = appendObjectKey(resolvedPath, rootKey);
     }
   }
 
-  if (rootArrayElementIds.length > 1) {
-    resolvedPath += `Root[${rootArrayElementIds.findIndex(
-      (id) => id === path[0],
-    )}]`;
-  } else {
-    resolvedPath += "{Root}";
-  }
+  for (let i = 1; i < chain.length; i++) {
+    const parentNode = nodeMap.get(chain[i - 1]);
+    const currentNode = nodeMap.get(chain[i]);
+    if (!parentNode || !currentNode) continue;
 
-  for (let i = 1; i < path.length; i++) {
-    const curId = path[i];
-    const curNode = nodes[+curId - 1];
+    if (parentNode.data?.type === "array") {
+      const children = childrenByParent.get(parentNode.id) ?? [];
+      const childIndex = children.indexOf(currentNode.id);
+      resolvedPath += `[${childIndex >= 0 ? childIndex : 0}]`;
 
-    if (!curNode) break;
-    if (curNode.data.type === "array") {
-      resolvedPath += `.${curNode.text}`;
-
-      if (i !== path.length - 1) {
-        const toNodeId = path[i + 1];
-        const idx = edgesMap.get(curId).indexOf(toNodeId);
-        resolvedPath += `[${idx}]`;
+      const arrayChildKey = normalizeKey(currentNode.text);
+      if (
+        (currentNode.data?.type === "object" ||
+          currentNode.data?.type === "array") &&
+        arrayChildKey
+      ) {
+        resolvedPath = appendObjectKey(resolvedPath, arrayChildKey);
       }
+      continue;
     }
 
-    if (curNode.data.type === "object") {
-      resolvedPath += `.${curNode.text}`;
+    const currentKey = normalizeKey(currentNode.text);
+    if (
+      (currentNode.data?.type === "object" ||
+        currentNode.data?.type === "array") &&
+      currentKey
+    ) {
+      resolvedPath = appendObjectKey(resolvedPath, currentKey);
     }
   }
 

--- a/src/core/json/inferSchema.ts
+++ b/src/core/json/inferSchema.ts
@@ -1,0 +1,141 @@
+type JsonSchema = {
+  $schema?: string;
+  title?: string;
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema;
+  anyOf?: JsonSchema[];
+  additionalProperties?: boolean;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (isPlainObject(value)) {
+    const keys = Object.keys(value).sort();
+    return `{${keys
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function dedupeSchemas(schemas: JsonSchema[]): JsonSchema[] {
+  const seen = new Set<string>();
+  const deduped: JsonSchema[] = [];
+
+  schemas.forEach((schema) => {
+    const key = stableStringify(schema);
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(schema);
+    }
+  });
+
+  return deduped;
+}
+
+function mergeSchemas(schemas: JsonSchema[]): JsonSchema {
+  const flatSchemas = schemas.flatMap((schema) =>
+    schema.anyOf ? schema.anyOf : [schema],
+  );
+  const unique = dedupeSchemas(flatSchemas);
+
+  if (unique.length === 1) {
+    return unique[0];
+  }
+
+  const objectSchemas = unique.filter(
+    (schema) => schema.type === "object" && schema.properties,
+  );
+  if (objectSchemas.length === unique.length) {
+    const allKeys = new Set<string>();
+    objectSchemas.forEach((schema) => {
+      Object.keys(schema.properties || {}).forEach((key) => allKeys.add(key));
+    });
+
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+    const schemaCount = objectSchemas.length;
+
+    Array.from(allKeys).forEach((key) => {
+      const keySchemas = objectSchemas
+        .map((schema) => schema.properties?.[key])
+        .filter((schema): schema is JsonSchema => Boolean(schema));
+      properties[key] = mergeSchemas(keySchemas);
+
+      const presentCount = objectSchemas.filter(
+        (schema) => schema.properties?.[key],
+      ).length;
+      if (presentCount === schemaCount) {
+        required.push(key);
+      }
+    });
+
+    return {
+      type: "object",
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+      additionalProperties: false,
+    };
+  }
+
+  return { anyOf: unique };
+}
+
+function inferNode(value: unknown): JsonSchema {
+  if (value === null) {
+    return { type: "null" };
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return { type: "array", items: {} };
+    }
+
+    const itemSchemas = value.map((item) => inferNode(item));
+    return {
+      type: "array",
+      items: mergeSchemas(itemSchemas),
+    };
+  }
+
+  if (isPlainObject(value)) {
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+
+    Object.entries(value).forEach(([key, val]) => {
+      properties[key] = inferNode(val);
+      required.push(key);
+    });
+
+    return {
+      type: "object",
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+      additionalProperties: false,
+    };
+  }
+
+  if (typeof value === "string") return { type: "string" };
+  if (typeof value === "boolean") return { type: "boolean" };
+  if (typeof value === "number") {
+    return { type: Number.isInteger(value) ? "integer" : "number" };
+  }
+
+  return {};
+}
+
+export function inferJsonSchema(value: unknown): JsonSchema {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    title: "InferredSchema",
+    ...inferNode(value),
+  };
+}

--- a/src/core/json/jsonParser.ts
+++ b/src/core/json/jsonParser.ts
@@ -27,6 +27,8 @@ export type States = {
   graph: Graph;
 };
 
+const PATH_COMPUTATION_THRESHOLD = 600;
+
 function initializeStates(): States {
   return {
     parentName: "",
@@ -72,10 +74,17 @@ export function parser(jsonStr: string): Graph {
       }
     }
 
-    states.graph.nodes = states.graph.nodes.map((node) => ({
-      ...node,
-      path: getNodePath(states.graph.nodes, states.graph.edges, node.id),
-    }));
+    if (states.graph.nodes.length <= PATH_COMPUTATION_THRESHOLD) {
+      states.graph.nodes = states.graph.nodes.map((node) => ({
+        ...node,
+        path: getNodePath(states.graph.nodes, states.graph.edges, node.id),
+      }));
+    } else {
+      states.graph.nodes = states.graph.nodes.map((node) => ({
+        ...node,
+        path: "",
+      }));
+    }
 
     return states.graph;
   } catch (error) {

--- a/src/core/node/index.tsx
+++ b/src/core/node/index.tsx
@@ -3,6 +3,7 @@ import { Node, NodeProps } from "reaflow";
 import { TextNode } from "@/core/node/TextNode";
 import { ObjectNode } from "@/core/node/ObjectNode";
 import { NodeData } from "@/core/type";
+import { useTree } from "@/store/useTree";
 
 export interface CustomNodeProps {
   node: NodeData;
@@ -22,6 +23,7 @@ interface CustomNode extends NodeProps {
 
 export const CustomNode = (nodeProps: CustomNode) => {
   const { text, data } = nodeProps.properties;
+  const setSelectedNode = useTree((state) => state.setSelectedNode);
 
   return (
     <Node
@@ -30,6 +32,7 @@ export const CustomNode = (nodeProps: CustomNode) => {
       ry={5}
       {...(data.isEmpty && rootProps)}
       label={<React.Fragment />}
+      onClick={(_, selectedNode) => setSelectedNode(selectedNode as NodeData)}
       className={`${
         nodeProps.isLightMode ? "!fill-[#f6f8fa]" : "!fill-[#2B2C3E]"
       }`}

--- a/src/pages/api/import-package-json.ts
+++ b/src/pages/api/import-package-json.ts
@@ -1,0 +1,274 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type GithubSource = {
+  type: "github";
+  owner: string;
+  repo: string;
+  ref?: string;
+  packagePath: string;
+  identifier: string;
+};
+
+type NpmSource = {
+  type: "npm";
+  packageName: string;
+  identifier: string;
+};
+
+type Source = GithubSource | NpmSource;
+
+type SuccessResponse = {
+  source: "github" | "npm";
+  identifier: string;
+  pretty: string;
+};
+
+const DEFAULT_GITHUB_HEADERS: Record<string, string> = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "jsontree-importer",
+};
+
+const BLOCKED_GITHUB_SEGMENTS = new Set([
+  "issues",
+  "pull",
+  "pulls",
+  "actions",
+  "releases",
+  "tags",
+  "commits",
+  "compare",
+  "security",
+  "wiki",
+  "projects",
+  "discussions",
+  "settings",
+]);
+
+function isHttpUrl(value: string) {
+  return /^https?:\/\//i.test(value);
+}
+
+function normalizeGithubRepo(value: string) {
+  return value.replace(/\.git$/i, "");
+}
+
+function buildPackagePath(basePath: string[]) {
+  if (basePath.length === 0) return "package.json";
+  if (basePath[basePath.length - 1] === "package.json") {
+    return basePath.join("/");
+  }
+  return `${basePath.join("/")}/package.json`;
+}
+
+function parseGithubFromUrl(url: URL): GithubSource {
+  const pathParts = url.pathname.split("/").filter(Boolean);
+  if (pathParts.length < 2) {
+    throw new Error("Invalid GitHub repository URL");
+  }
+
+  const owner = decodeURIComponent(pathParts[0]);
+  const repo = normalizeGithubRepo(decodeURIComponent(pathParts[1]));
+  if (!owner || !repo) {
+    throw new Error("Invalid GitHub repository URL");
+  }
+
+  let ref: string | undefined;
+  let basePath: string[] = [];
+
+  if (pathParts[2] === "tree" || pathParts[2] === "blob") {
+    if (!pathParts[3]) {
+      throw new Error("GitHub branch is missing in the URL");
+    }
+    ref = decodeURIComponent(pathParts[3]);
+    basePath = pathParts.slice(4).map((segment) => decodeURIComponent(segment));
+  } else if (pathParts.length > 2) {
+    const route = pathParts[2];
+    if (BLOCKED_GITHUB_SEGMENTS.has(route)) {
+      throw new Error(
+        "Unsupported GitHub page. Use repository root or tree/blob URL.",
+      );
+    }
+    basePath = pathParts.slice(2).map((segment) => decodeURIComponent(segment));
+  }
+
+  return {
+    type: "github",
+    owner,
+    repo,
+    ref,
+    packagePath: buildPackagePath(basePath),
+    identifier: `${owner}/${repo}`,
+  };
+}
+
+function parseNpmFromUrl(url: URL): NpmSource {
+  const pathParts = url.pathname.split("/").filter(Boolean);
+  if (pathParts[0] !== "package") {
+    throw new Error("Unsupported npm URL. Use npm package page URL.");
+  }
+
+  const first = pathParts[1];
+  if (!first) {
+    throw new Error("npm package is missing in URL");
+  }
+
+  let packageName = decodeURIComponent(first);
+  if (packageName.startsWith("@")) {
+    const second = pathParts[2];
+    if (!second) {
+      throw new Error("Scoped npm package is incomplete");
+    }
+    packageName = `${packageName}/${decodeURIComponent(second)}`;
+  }
+
+  return {
+    type: "npm",
+    packageName,
+    identifier: packageName,
+  };
+}
+
+function parseGithubShorthand(value: string): GithubSource | null {
+  const match = value.match(/^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)(?:\.git)?$/);
+  if (!match) return null;
+
+  return {
+    type: "github",
+    owner: match[1],
+    repo: normalizeGithubRepo(match[2]),
+    packagePath: "package.json",
+    identifier: `${match[1]}/${normalizeGithubRepo(match[2])}`,
+  };
+}
+
+function resolveSource(rawValue: string): Source {
+  const value = rawValue.trim();
+  if (!value) {
+    throw new Error("Source is required");
+  }
+
+  if (isHttpUrl(value)) {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      throw new Error("Invalid URL");
+    }
+
+    const host = url.hostname.toLowerCase();
+    if (host === "github.com" || host === "www.github.com") {
+      return parseGithubFromUrl(url);
+    }
+    if (host === "npmjs.com" || host === "www.npmjs.com") {
+      return parseNpmFromUrl(url);
+    }
+    throw new Error("Unsupported domain. Use github.com or npmjs.com.");
+  }
+
+  const githubSource = parseGithubShorthand(value);
+  if (githubSource) return githubSource;
+
+  return {
+    type: "npm",
+    packageName: value,
+    identifier: value,
+  };
+}
+
+async function fetchGithubPackageJson(source: GithubSource): Promise<object> {
+  const encodedPath = source.packagePath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const endpoint = new URL(
+    `https://api.github.com/repos/${encodeURIComponent(
+      source.owner,
+    )}/${encodeURIComponent(source.repo)}/contents/${encodedPath}`,
+  );
+  if (source.ref) {
+    endpoint.searchParams.set("ref", source.ref);
+  }
+
+  const headers: Record<string, string> = { ...DEFAULT_GITHUB_HEADERS };
+  const token =
+    process.env.GITHUB_TOKEN ||
+    process.env.GH_TOKEN ||
+    process.env.GITHUB_PAT ||
+    "";
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(endpoint.toString(), {
+    headers,
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message =
+      payload?.message ||
+      `GitHub request failed with status ${String(response.status)}`;
+    throw new Error(message);
+  }
+
+  const payload = await response.json();
+  const encodedContent = payload?.content;
+  if (!encodedContent || payload?.encoding !== "base64") {
+    throw new Error("package.json not found in the provided GitHub source");
+  }
+
+  const rawContent = Buffer.from(encodedContent, "base64").toString("utf8");
+  return JSON.parse(rawContent);
+}
+
+async function fetchNpmPackageJson(source: NpmSource): Promise<object> {
+  const endpoint = `https://registry.npmjs.org/${encodeURIComponent(
+    source.packageName,
+  )}/latest`;
+  const response = await fetch(endpoint, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "jsontree-importer",
+    },
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message =
+      payload?.error ||
+      `npm request failed with status ${String(response.status)}`;
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | { error: string }>,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const sourceInput =
+      typeof req.body?.source === "string" ? req.body.source : "";
+    const source = resolveSource(sourceInput);
+
+    const packageJson =
+      source.type === "github"
+        ? await fetchGithubPackageJson(source)
+        : await fetchNpmPackageJson(source);
+
+    return res.status(200).json({
+      source: source.type,
+      identifier: source.identifier,
+      pretty: JSON.stringify(packageJson, null, 2),
+    });
+  } catch (error: any) {
+    const message = error?.message || "Failed to import package.json";
+    return res.status(400).json({ error: message });
+  }
+}

--- a/src/store/useApp.ts
+++ b/src/store/useApp.ts
@@ -44,8 +44,15 @@ export const useApp = create<FileStates & JsonActions>()((set, get) => ({
   getHasChanges: () => get().hasChanges,
   setContents: async ({ contents, hasChanges = true, skipUpdate = false }) => {
     try {
-      set({ ...(contents && { contents }), error: null, hasChanges });
-      const json = await contentToJson(get().contents);
+      const hasContentsUpdate = contents !== undefined;
+      const nextContents = hasContentsUpdate ? contents : get().contents;
+
+      set({
+        ...(hasContentsUpdate ? { contents } : {}),
+        error: null,
+        hasChanges,
+      });
+      const json = await contentToJson(nextContents);
       if (!useStored.getState().liveTransform && skipUpdate) return;
 
       debouncedUpdateJson(json);

--- a/src/store/useApp.ts
+++ b/src/store/useApp.ts
@@ -14,52 +14,121 @@ type SetContents = {
 interface JsonActions {
   getContents: () => string;
   getHasChanges: () => boolean;
+  applyPendingTransform: () => Promise<void>;
   setError: (error: object | null | string) => void;
   setHasChanges: (hasChanges: boolean) => void;
   setContents: (data: SetContents) => void;
   clear: () => void;
 }
 
+const TRANSFORM_DEBOUNCE_MS = 800;
+const LARGE_JSON_AUTO_MANUAL_THRESHOLD = 300 * 1024;
+
 const initialStates = {
   contents: JSON_TEMPLATE,
   error: null as any,
   hasChanges: false,
+  autoManualMode: false,
+  pendingTransform: false,
 };
 
 export type FileStates = typeof initialStates;
 
-const debouncedUpdateJson = debounce(
-  (value: unknown) =>
-    useJson.getState().setJson(JSON.stringify(value, null, 2)),
-  800,
+const getErrorMessage = (error: any) => {
+  if (error?.mark?.snippet) return error.mark.snippet;
+  if (error?.message) return error.message;
+  return "Invalid JSON format";
+};
+
+const syncJsonGraph = async (contents: string) => {
+  const json = await contentToJson(contents);
+  useJson.getState().setJson(JSON.stringify(json, null, 2));
+};
+
+const debouncedSyncJsonGraph = debounce(
+  async (
+    contents: string,
+    onSuccess: () => void,
+    onError: (error: any) => void,
+  ) => {
+    try {
+      await syncJsonGraph(contents);
+      onSuccess();
+    } catch (error: any) {
+      onError(error);
+    }
+  },
+  TRANSFORM_DEBOUNCE_MS,
 );
 
 export const useApp = create<FileStates & JsonActions>()((set, get) => ({
   ...initialStates,
   clear: () => {
-    set({ contents: "" });
+    debouncedSyncJsonGraph.cancel();
+    set({
+      contents: "",
+      autoManualMode: false,
+      pendingTransform: false,
+    });
     useJson.getState().clear();
+  },
+  applyPendingTransform: async () => {
+    try {
+      const nextContents = get().contents;
+      debouncedSyncJsonGraph.cancel();
+      set({ error: null, pendingTransform: true });
+
+      await syncJsonGraph(nextContents);
+      set({ pendingTransform: false });
+    } catch (error: any) {
+      set({ error: getErrorMessage(error), pendingTransform: true });
+    }
   },
   getContents: () => get().contents,
   getHasChanges: () => get().hasChanges,
   setContents: async ({ contents, hasChanges = true, skipUpdate = false }) => {
-    try {
-      const hasContentsUpdate = contents !== undefined;
-      const nextContents = hasContentsUpdate ? contents : get().contents;
+    const hasContentsUpdate = contents !== undefined;
+    const nextContents = hasContentsUpdate ? contents : get().contents;
+    const isLargeJson = nextContents.length >= LARGE_JSON_AUTO_MANUAL_THRESHOLD;
+    const liveTransform = useStored.getState().liveTransform;
+    const shouldUseManualMode = skipUpdate && (isLargeJson || !liveTransform);
 
-      set({
-        ...(hasContentsUpdate ? { contents } : {}),
-        error: null,
-        hasChanges,
-      });
-      const json = await contentToJson(nextContents);
-      if (!useStored.getState().liveTransform && skipUpdate) return;
+    set({
+      ...(hasContentsUpdate ? { contents: nextContents } : {}),
+      error: null,
+      hasChanges,
+      autoManualMode: isLargeJson,
+      pendingTransform: skipUpdate ? true : false,
+    });
 
-      debouncedUpdateJson(json);
-    } catch (error: any) {
-      if (error?.mark?.snippet) return set({ error: error.mark.snippet });
-      if (error?.message) set({ error: error.message });
+    if (shouldUseManualMode) {
+      debouncedSyncJsonGraph.cancel();
+      return;
     }
+
+    if (!skipUpdate) {
+      try {
+        debouncedSyncJsonGraph.cancel();
+        await syncJsonGraph(nextContents);
+        set({ pendingTransform: false });
+      } catch (error: any) {
+        set({
+          error: getErrorMessage(error),
+          pendingTransform: true,
+        });
+      }
+      return;
+    }
+
+    debouncedSyncJsonGraph(
+      nextContents,
+      () => set({ pendingTransform: false }),
+      (error: any) =>
+        set({
+          error: getErrorMessage(error),
+          pendingTransform: true,
+        }),
+    );
   },
   setError: (error) => set({ error }),
   setHasChanges: (hasChanges) => set({ hasChanges }),

--- a/src/store/useApp.ts
+++ b/src/store/useApp.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import debounce from "lodash.debounce";
 import { contentToJson } from "@/core/json/jsonAdapter";
+import { inferJsonSchema } from "@/core/json/inferSchema";
 import { useJson } from "@/store/useJson";
 import { useStored } from "@/store/useStored";
 import { JSON_TEMPLATE } from "@/constants/json";
@@ -15,6 +16,7 @@ interface JsonActions {
   getContents: () => string;
   getHasChanges: () => boolean;
   applyPendingTransform: () => Promise<void>;
+  toggleSchemaMode: () => Promise<void>;
   setError: (error: object | null | string) => void;
   setHasChanges: (hasChanges: boolean) => void;
   setContents: (data: SetContents) => void;
@@ -30,6 +32,8 @@ const initialStates = {
   hasChanges: false,
   autoManualMode: false,
   pendingTransform: false,
+  schemaMode: false,
+  schemaSource: "",
 };
 
 export type FileStates = typeof initialStates;
@@ -69,6 +73,8 @@ export const useApp = create<FileStates & JsonActions>()((set, get) => ({
       contents: "",
       autoManualMode: false,
       pendingTransform: false,
+      schemaMode: false,
+      schemaSource: "",
     });
     useJson.getState().clear();
   },
@@ -82,6 +88,42 @@ export const useApp = create<FileStates & JsonActions>()((set, get) => ({
       set({ pendingTransform: false });
     } catch (error: any) {
       set({ error: getErrorMessage(error), pendingTransform: true });
+    }
+  },
+  toggleSchemaMode: async () => {
+    if (get().schemaMode) {
+      const sourceContents = get().schemaSource;
+      set({ schemaMode: false, schemaSource: "" });
+      if (sourceContents) {
+        await get().setContents({
+          contents: sourceContents,
+          hasChanges: true,
+          skipUpdate: false,
+        });
+      }
+      return;
+    }
+
+    try {
+      const originalContents = get().contents;
+      const json = await contentToJson(originalContents);
+      const inferredSchema = inferJsonSchema(json);
+
+      set({
+        schemaMode: true,
+        schemaSource: originalContents,
+      });
+      await get().setContents({
+        contents: JSON.stringify(inferredSchema, null, 2),
+        hasChanges: true,
+        skipUpdate: false,
+      });
+    } catch (error: any) {
+      set({
+        error: getErrorMessage(error),
+        schemaMode: false,
+        schemaSource: "",
+      });
     }
   },
   getContents: () => get().contents,

--- a/src/store/useApp.ts
+++ b/src/store/useApp.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import debounce from "lodash.debounce";
 import { contentToJson } from "@/core/json/jsonAdapter";
+import { getJsonStats, JsonStats } from "@/core/json/getJsonStats";
 import { inferJsonSchema } from "@/core/json/inferSchema";
 import { useJson } from "@/store/useJson";
 import { useStored } from "@/store/useStored";
@@ -32,6 +33,7 @@ const initialStates = {
   hasChanges: false,
   autoManualMode: false,
   pendingTransform: false,
+  stats: null as JsonStats | null,
   schemaMode: false,
   schemaSource: "",
 };
@@ -47,17 +49,18 @@ const getErrorMessage = (error: any) => {
 const syncJsonGraph = async (contents: string) => {
   const json = await contentToJson(contents);
   useJson.getState().setJson(JSON.stringify(json, null, 2));
+  return json;
 };
 
 const debouncedSyncJsonGraph = debounce(
   async (
     contents: string,
-    onSuccess: () => void,
+    onSuccess: (json: unknown) => void,
     onError: (error: any) => void,
   ) => {
     try {
-      await syncJsonGraph(contents);
-      onSuccess();
+      const json = await syncJsonGraph(contents);
+      onSuccess(json);
     } catch (error: any) {
       onError(error);
     }
@@ -73,6 +76,7 @@ export const useApp = create<FileStates & JsonActions>()((set, get) => ({
       contents: "",
       autoManualMode: false,
       pendingTransform: false,
+      stats: null,
       schemaMode: false,
       schemaSource: "",
     });
@@ -84,8 +88,8 @@ export const useApp = create<FileStates & JsonActions>()((set, get) => ({
       debouncedSyncJsonGraph.cancel();
       set({ error: null, pendingTransform: true });
 
-      await syncJsonGraph(nextContents);
-      set({ pendingTransform: false });
+      const json = await syncJsonGraph(nextContents);
+      set({ pendingTransform: false, stats: getJsonStats(json) });
     } catch (error: any) {
       set({ error: getErrorMessage(error), pendingTransform: true });
     }
@@ -151,8 +155,8 @@ export const useApp = create<FileStates & JsonActions>()((set, get) => ({
     if (!skipUpdate) {
       try {
         debouncedSyncJsonGraph.cancel();
-        await syncJsonGraph(nextContents);
-        set({ pendingTransform: false });
+        const json = await syncJsonGraph(nextContents);
+        set({ pendingTransform: false, stats: getJsonStats(json) });
       } catch (error: any) {
         set({
           error: getErrorMessage(error),
@@ -164,7 +168,11 @@ export const useApp = create<FileStates & JsonActions>()((set, get) => ({
 
     debouncedSyncJsonGraph(
       nextContents,
-      () => set({ pendingTransform: false }),
+      (json) =>
+        set({
+          pendingTransform: false,
+          stats: getJsonStats(json),
+        }),
       (error: any) =>
         set({
           error: getErrorMessage(error),

--- a/src/store/useTree.ts
+++ b/src/store/useTree.ts
@@ -8,6 +8,7 @@ import {
   GraphWorkerRequest,
   GraphWorkerResponse,
 } from "@/core/graph/workerTypes";
+import { getNodePath } from "@/core/json/getNodePath";
 import { parser } from "@/core/json/jsonParser";
 import { useJson } from "@/store/useJson";
 import { EdgeData, NodeData } from "@/core/type";
@@ -96,10 +97,19 @@ export const useTree = create<Graph & GraphActions>((set, get) => ({
       totalNodes: 0,
       loadedEdges: 0,
       totalEdges: 0,
+      selectedNode: {} as NodeData,
+      path: "",
       loading: false,
     });
   },
-  setSelectedNode: (nodeData) => set({ selectedNode: nodeData }),
+  setSelectedNode: (nodeData) =>
+    set((state) => ({
+      selectedNode: nodeData,
+      path:
+        nodeData.path && nodeData.path.length > 0
+          ? nodeData.path
+          : getNodePath(state.nodes, state.edges, nodeData.id),
+    })),
   setHoveredNodeId: (nodeId) => set({ hoveredNodeId: nodeId }),
   setGraph: (data, options) => {
     const graphContent = data ?? useJson.getState().json;
@@ -115,6 +125,8 @@ export const useTree = create<Graph & GraphActions>((set, get) => ({
       totalNodes: 0,
       loadedEdges: 0,
       totalEdges: 0,
+      selectedNode: {} as NodeData,
+      path: "",
       loading: true,
       hoveredNodeId: null,
       ...options,

--- a/src/store/useTree.ts
+++ b/src/store/useTree.ts
@@ -209,6 +209,43 @@ export const useTree = create<Graph & GraphActions>((set, get) => ({
   },
   setLoading: (loading) => set({ loading }),
   expandNodes: (nodeId) => {
+    if (get().largeGraphMode) {
+      const edges = get().edges;
+      const nodes = get().nodes;
+      const directEdges = edges.filter((edge) => edge.from === nodeId);
+      const directNodeIds = directEdges
+        .map((edge) => edge.to)
+        .filter((id): id is string => Boolean(id));
+
+      const collapsedParentsWithoutCurrent = get().collapsedParents.filter(
+        (cp) => cp !== nodeId,
+      );
+      const directParentNodeIds = nodes
+        .filter(
+          (node) => directNodeIds.includes(node.id) && node.data?.isParent,
+        )
+        .map((node) => node.id);
+
+      const collapsedParents = Array.from(
+        new Set(collapsedParentsWithoutCurrent.concat(directParentNodeIds)),
+      );
+      const collapsedNodes = get().collapsedNodes.filter(
+        (id) => !directNodeIds.includes(id),
+      );
+      const directEdgeIds = directEdges.map((edge) => edge.id);
+      const collapsedEdges = get().collapsedEdges.filter(
+        (id) => !directEdgeIds.includes(id),
+      );
+
+      set({
+        collapsedParents,
+        collapsedNodes,
+        collapsedEdges,
+        graphCollapsed: collapsedNodes.length > 0 || collapsedEdges.length > 0,
+      });
+      return;
+    }
+
     const [childrenNodes, matchingNodes] = getOutgoers(
       nodeId,
       get().nodes,
@@ -256,12 +293,21 @@ export const useTree = create<Graph & GraphActions>((set, get) => ({
 
     const nodeIds = childrenNodes.map((node) => node.id);
     const edgeIds = childrenEdges.map((edge) => edge.id);
+    const collapsedParents = Array.from(
+      new Set(get().collapsedParents.concat(nodeId)),
+    );
+    const collapsedNodes = Array.from(
+      new Set(get().collapsedNodes.concat(nodeIds)),
+    );
+    const collapsedEdges = Array.from(
+      new Set(get().collapsedEdges.concat(edgeIds)),
+    );
 
     set({
-      collapsedParents: get().collapsedParents.concat(nodeId),
-      collapsedNodes: get().collapsedNodes.concat(nodeIds),
-      collapsedEdges: get().collapsedEdges.concat(edgeIds),
-      graphCollapsed: !!get().collapsedNodes.concat(nodeIds).length,
+      collapsedParents,
+      collapsedNodes,
+      collapsedEdges,
+      graphCollapsed: collapsedNodes.length > 0 || collapsedEdges.length > 0,
     });
   },
   collapseGraph: () => {

--- a/src/store/useTree.ts
+++ b/src/store/useTree.ts
@@ -2,16 +2,50 @@ import { create } from "zustand";
 import { ReactZoomPanPinchRef } from "react-zoom-pan-pinch";
 import { CanvasDirection } from "reaflow/dist/layout/elkLayout";
 import { getChildrenEdges } from "@/core/graph/getChildrenEdges";
+import { getCollapsedGraphState } from "@/core/graph/getCollapsedGraphState";
 import { getOutgoers } from "@/core/graph/getOutgoers";
+import {
+  GraphWorkerRequest,
+  GraphWorkerResponse,
+} from "@/core/graph/workerTypes";
 import { parser } from "@/core/json/jsonParser";
-import { useJson } from "@/store//useJson";
+import { useJson } from "@/store/useJson";
 import { EdgeData, NodeData } from "@/core/type";
+
+const AUTO_COLLAPSE_NODE_THRESHOLD = 450;
+const GRAPH_WORKER_CHUNK_SIZE = 240;
+
+let graphWorker: Worker | null = null;
+let currentJobId = 0;
+
+const resetGraphWorker = () => {
+  if (graphWorker) {
+    graphWorker.terminate();
+    graphWorker = null;
+  }
+};
+
+const getGraphWorker = (restart = false) => {
+  if (typeof window === "undefined") return null;
+  if (restart) resetGraphWorker();
+  if (!graphWorker) {
+    graphWorker = new Worker(
+      new URL("../workers/graph.worker.ts", import.meta.url),
+    );
+  }
+  return graphWorker;
+};
 
 const initialStates = {
   zoomPanPinch: null as ReactZoomPanPinchRef | null,
   direction: "RIGHT" as CanvasDirection,
   loading: true,
+  loadedNodes: 0,
+  totalNodes: 0,
+  loadedEdges: 0,
+  totalEdges: 0,
   graphCollapsed: false,
+  largeGraphMode: false,
   foldNodes: false,
   fullscreen: false,
   nodes: [] as NodeData[],
@@ -27,7 +61,7 @@ const initialStates = {
 export type Graph = typeof initialStates;
 
 interface GraphActions {
-  setGraph: (json?: string, options?: Partial<Graph>[]) => void;
+  setGraph: (json?: string, options?: Partial<Graph>) => void;
   setLoading: (loading: boolean) => void;
   setDirection: (direction: CanvasDirection) => void;
   setZoomPanPinch: (ref: ReactZoomPanPinchRef) => void;
@@ -48,22 +82,126 @@ interface GraphActions {
 
 export const useTree = create<Graph & GraphActions>((set, get) => ({
   ...initialStates,
-  clearGraph: () => set({ nodes: [], edges: [], loading: false }),
-  setSelectedNode: (nodeData) => set({ selectedNode: nodeData }),
-  setHoveredNodeId: (nodeId) => set({ hoveredNodeId: nodeId }),
-  setGraph: (data, options) => {
-    const { nodes, edges } = parser(data ?? useJson.getState().json);
+  clearGraph: () => {
+    resetGraphWorker();
     set({
-      nodes,
-      edges,
+      nodes: [],
+      edges: [],
       collapsedParents: [],
       collapsedNodes: [],
       collapsedEdges: [],
       graphCollapsed: false,
+      largeGraphMode: false,
+      loadedNodes: 0,
+      totalNodes: 0,
+      loadedEdges: 0,
+      totalEdges: 0,
+      loading: false,
+    });
+  },
+  setSelectedNode: (nodeData) => set({ selectedNode: nodeData }),
+  setHoveredNodeId: (nodeId) => set({ hoveredNodeId: nodeId }),
+  setGraph: (data, options) => {
+    const graphContent = data ?? useJson.getState().json;
+    set({
+      nodes: [],
+      edges: [],
+      collapsedParents: [],
+      collapsedNodes: [],
+      collapsedEdges: [],
+      graphCollapsed: false,
+      largeGraphMode: false,
+      loadedNodes: 0,
+      totalNodes: 0,
+      loadedEdges: 0,
+      totalEdges: 0,
       loading: true,
       hoveredNodeId: null,
       ...options,
     });
+
+    const worker = getGraphWorker(true);
+    if (!worker) {
+      const { nodes, edges } = parser(graphContent);
+      const shouldAutoCollapse = nodes.length > AUTO_COLLAPSE_NODE_THRESHOLD;
+      const collapsedStates = shouldAutoCollapse
+        ? getCollapsedGraphState(nodes, edges)
+        : {
+            collapsedParents: [],
+            collapsedNodes: [],
+            collapsedEdges: [],
+            graphCollapsed: false,
+          };
+
+      set({
+        nodes,
+        edges,
+        ...collapsedStates,
+        largeGraphMode: shouldAutoCollapse,
+        loadedNodes: nodes.length,
+        totalNodes: nodes.length,
+        loadedEdges: edges.length,
+        totalEdges: edges.length,
+        loading: false,
+      });
+      return;
+    }
+
+    currentJobId += 1;
+    const jobId = currentJobId;
+
+    const onMessage = (event: MessageEvent<GraphWorkerResponse>) => {
+      const message = event.data;
+      if (message.jobId !== jobId) return;
+
+      if (message.type === "GRAPH_START") {
+        set({
+          largeGraphMode: message.largeGraphMode,
+          collapsedParents: message.collapsedParents,
+          collapsedNodes: message.collapsedNodes,
+          collapsedEdges: message.collapsedEdges,
+          graphCollapsed: message.graphCollapsed,
+          totalNodes: message.totalNodes,
+          totalEdges: message.totalEdges,
+          loadedNodes: 0,
+          loadedEdges: 0,
+          loading: true,
+        });
+        return;
+      }
+
+      if (message.type === "GRAPH_CHUNK") {
+        set((state) => ({
+          nodes: state.nodes.concat(message.nodes),
+          edges: state.edges.concat(message.edges),
+          loadedNodes: message.loadedNodes,
+          loadedEdges: message.loadedEdges,
+          loading: !message.done,
+        }));
+
+        if (message.done) {
+          worker.removeEventListener("message", onMessage);
+        }
+        return;
+      }
+
+      if (message.type === "GRAPH_ERROR") {
+        set({
+          loading: false,
+        });
+        worker.removeEventListener("message", onMessage);
+      }
+    };
+
+    worker.addEventListener("message", onMessage);
+    const payload: GraphWorkerRequest = {
+      type: "BUILD_GRAPH",
+      jobId,
+      json: graphContent,
+      chunkSize: GRAPH_WORKER_CHUNK_SIZE,
+      autoCollapseThreshold: AUTO_COLLAPSE_NODE_THRESHOLD,
+    };
+    worker.postMessage(payload);
   },
   setDirection: (direction = "RIGHT") => {
     set({ direction });
@@ -127,36 +265,8 @@ export const useTree = create<Graph & GraphActions>((set, get) => ({
     });
   },
   collapseGraph: () => {
-    const edges = get().edges;
-    const tos = edges.map((edge) => edge.to);
-    const froms = edges.map((edge) => edge.from);
-    const parentNodesIds = froms.filter((id) => !tos.includes(id));
-    const secondDegreeNodesIds = edges
-      .filter((edge) => parentNodesIds.includes(edge.from))
-      .map((edge) => edge.to);
-
-    const collapsedParents = get()
-      .nodes.filter(
-        (node) => !parentNodesIds.includes(node.id) && node.data.isParent,
-      )
-      .map((node) => node.id);
-
-    const collapsedNodes = get()
-      .nodes.filter(
-        (node) =>
-          !parentNodesIds.includes(node.id) &&
-          !secondDegreeNodesIds.includes(node.id),
-      )
-      .map((node) => node.id);
-
-    set({
-      collapsedParents,
-      collapsedNodes,
-      collapsedEdges: get()
-        .edges.filter((edge) => !parentNodesIds.includes(edge.from))
-        .map((edge) => edge.id),
-      graphCollapsed: true,
-    });
+    const collapsedStates = getCollapsedGraphState(get().nodes, get().edges);
+    set(collapsedStates);
   },
   expandGraph: () => {
     set({

--- a/src/workers/graph.worker.ts
+++ b/src/workers/graph.worker.ts
@@ -1,0 +1,86 @@
+import { getCollapsedGraphState } from "@/core/graph/getCollapsedGraphState";
+import {
+  GraphWorkerRequest,
+  GraphWorkerResponse,
+} from "@/core/graph/workerTypes";
+import { parser } from "@/core/json/jsonParser";
+
+const waitForNextFrame = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 16);
+  });
+
+const postWorkerMessage = (message: GraphWorkerResponse) => {
+  self.postMessage(message);
+};
+
+self.addEventListener("message", (event: MessageEvent<GraphWorkerRequest>) => {
+  const request = event.data;
+
+  if (request.type !== "BUILD_GRAPH") return;
+
+  const { jobId, json, chunkSize, autoCollapseThreshold } = request;
+
+  void (async () => {
+    try {
+      const { nodes, edges } = parser(json);
+      const largeGraphMode = nodes.length > autoCollapseThreshold;
+      const collapsedStates = largeGraphMode
+        ? getCollapsedGraphState(nodes, edges)
+        : {
+            collapsedParents: [],
+            collapsedNodes: [],
+            collapsedEdges: [],
+            graphCollapsed: false,
+          };
+
+      postWorkerMessage({
+        type: "GRAPH_START",
+        jobId,
+        totalNodes: nodes.length,
+        totalEdges: edges.length,
+        largeGraphMode,
+        ...collapsedStates,
+      });
+
+      const maxLength = Math.max(nodes.length, edges.length);
+      if (maxLength === 0) {
+        postWorkerMessage({
+          type: "GRAPH_CHUNK",
+          jobId,
+          nodes: [],
+          edges: [],
+          loadedNodes: 0,
+          loadedEdges: 0,
+          done: true,
+        });
+        return;
+      }
+
+      for (let start = 0; start < maxLength; start += chunkSize) {
+        const end = start + chunkSize;
+        const done = end >= maxLength;
+
+        postWorkerMessage({
+          type: "GRAPH_CHUNK",
+          jobId,
+          nodes: nodes.slice(start, end),
+          edges: edges.slice(start, end),
+          loadedNodes: Math.min(end, nodes.length),
+          loadedEdges: Math.min(end, edges.length),
+          done,
+        });
+
+        if (!done) {
+          await waitForNextFrame();
+        }
+      }
+    } catch (error: any) {
+      postWorkerMessage({
+        type: "GRAPH_ERROR",
+        jobId,
+        message: error?.message || "Failed to build graph",
+      });
+    }
+  })();
+});


### PR DESCRIPTION
## Overview
This PR expands JsonTree with a full large-JSON workflow and usability improvements, while keeping previous behavior compatible.

## Included Changes
- Fixes editor state updates when content is cleared (`""`) and hardens external links with `rel="noopener noreferrer"`.
- Moves graph construction to a Web Worker with progressive chunked rendering to reduce UI blocking.
- Adds `package.json` import flow (GitHub/NPM) and lazy tree expansion behavior.
- Adds **Schema mode** with inferred structure/types and toolbar toggle.
- Adds **JSON Stats** (modal + live summary in infobar).
- Adds **copyable JSONPath** for the selected node in the graph.

## Commits in This PR
- `bd1a312` fix editor content update and secure external link
- `834a8a2` perf: build graph in worker with progressive rendering
- `73a974d` feat: add package.json import flow and lazy tree expansion
- `5644277` feat: add inferred schema mode with toolbar toggle
- `97a3535` feat: add JSON statistics modal and live summary
- `ae4beae` feat: add copyable JSONPath for selected nodes

## Linked Issue
- https://github.com/BUMBAIYA/jsontree/issues/9
- Closes #9

## Validation
- `npm run lint`
- `npm run build`
